### PR TITLE
Fix Config.initialized to do environment var substitution on nested keys

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -13,12 +13,17 @@ var initialize = _.once(function (configFilePath, overrides) {
     config = _.merge({}, require(configFilePath), overrides);
 
     // Replace any "process.env.*" by its corresponding value
-    _.forOwn(config, function(value, key){
-        var env = /^process\.env\.(.+)$/.exec(value);
-        if(env) {
-          config[key] = process.env[env[1]];
-        }
-    });
+    var replaceEnvVars = function(obj) {
+        _.forOwn(obj, function(value, key){
+            var env = /^process\.env\.(.+)$/.exec(value);
+            if(env) {
+              obj[key] = process.env[env[1]];
+            }
+            replaceEnvVars(value);
+        });
+    };
+
+    replaceEnvVars(config);
 
     return config;
 });


### PR DESCRIPTION
Did not previously do substitution on gcm.apiKey