### PR TITLE
Fix broken web app if pushserver is not served at domain's root

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -139,7 +139,7 @@
 
         // Init user list
         toastr.info('Loading users...')
-        $.get('/users', function(data) {
+        $.get('./users', function(data) {
             var users = data.users,
                 usersSelect = $('#users');
 
@@ -191,7 +191,7 @@
                 pushNotification.ios= JSON.parse(formValues.iosOptions);
 
             $.ajax({
-                url: '/send',
+                url: './send',
                 type: 'POST',
                 data: JSON.stringify(pushNotification),
                 contentType: 'application/json',


### PR DESCRIPTION
The web app is broken if you set a proxy so that `node-pushserver` can be reached at http://domain.com/pushserver/ for example. 

This PR fixes it using relative paths instead of absolute ones.
