### PR TITLE
Add support for Amazon's ADM using node-adm module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Push Server
 
-Push Server is a cross-plateform push server based on [node-apn](https://github.com/argon/node-apn) and [node-gcm](https://github.com/ToothlessGear/node-gcm). Push Server currently supports iOS (APN) and android (GCM) platforms. It uses mongoDB to store the push tokens. 
+Push Server is a cross-plateform push server based on [node-apn](https://github.com/argon/node-apn), [node-gcm](https://github.com/ToothlessGear/node-gcm) and [node-adm](https://github.com/umano/node-adm). Push Server currently supports iOS (APN), android (GCM) and amazon (ADM) platforms. It uses mongoDB to store the push tokens.
 Note that this server is not meant to be used as a front facing server as there's no particular security implemented.
 
 [![NPM](https://nodei.co/npm/node-pushserver.png?downloads=true&stars=true)](https://nodei.co/npm/node-pushserver/)
@@ -44,6 +44,11 @@ If you checked out this project from github, you can find a configuration file e
         "apiKey": "YOUR_API_KEY_HERE"
     },
 
+    "adm": {
+        "client_id": "YOUR_CLIENT_ID_HERE",
+        "client_secret": "YOUR_CLIENT_SECRET_HERE"
+    },
+
     "apn": {
         "connection": {
             "gateway": "gateway.sandbox.push.apple.com",
@@ -63,6 +68,8 @@ If you checked out this project from github, you can find a configuration file e
 ```
 
 + Checkout [GCM documentation](http://developer.android.com/guide/google/gcm/gs.html) to get your API key.
+
++ Read [ADM documentation](https://developer.amazon.com/public/apis/engage/device-messaging/tech-docs/02-obtaining-adm-credentials) to get your Client Credentials.
 
 +  Read [Apple's Notification guide](https://developer.apple.com/library/ios/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Introduction.html) to know how to get your certificates for APN.
 
@@ -121,6 +128,12 @@ http://domain:port/send (POST)
       "message": "Your message here"
     }
   },
+  "amazon": {
+    "collapseKey": "optional",
+    "data": {
+      "message": "Your message here"
+    }
+  },
   "ios": {
     "badge": 0,
     "alert": "Your message here",
@@ -130,7 +143,7 @@ http://domain:port/send (POST)
 ```
 
 + "users" is optionnal, but must be an array if set. If not defined, the push message will be sent to every user (filtered by target).
-+ You can send push messages to Android or iOS devices, or both, by using the "android" and "ios" fields with appropriate options. See GCM and APN documentation to find the available options. 
++ You can send push messages to Android, Amazon or iOS devices, or both, by using the "android", "amazon" and "ios" fields with appropriate options. See GCM, ADM and APN documentation to find the available options.
 
 #### Send push notifications
 ```
@@ -144,6 +157,12 @@ http://domain:port/sendBatch (POST)
   "notifications": [{
       "users": ["user1", "user2"],
       "android": {
+        "collapseKey": "optional",
+        "data": {
+          "message": "Your message here"
+        }
+      },
+      "amazon": {
         "collapseKey": "optional",
         "data": {
           "message": "Your message here"
@@ -182,7 +201,7 @@ http://domain:port/subscribe (POST)
 }
 ```
 + All field are required
-+ "type" can be either "android" or "ios"
++ "type" can be either "android", "amazon" or "ios"
 + A user can be linked to several devices and a device can be linked to serveral users.
 
 #### Unsubscribe
@@ -241,6 +260,7 @@ http://domain:port/users/{user}/associations (GET)
 
   * [node-apn](https://github.com/argon/node-apn)
   * [node-gcm](https://github.com/ToothlessGear/node-gcm)
+  * [node-adm](https://github.com/umano/node-adm)
   * [express](https://github.com/visionmedia/express)
   * [mongoose](https://github.com/LearnBoost/mongoose)
   * [lodash](https://github.com/bestiejs/lodash.git )

--- a/example.config.json
+++ b/example.config.json
@@ -7,6 +7,11 @@
         "apiKey": "YOUR_API_KEY_HERE"
     },
 
+    "adm": {
+        "client_id": "YOUR_API_KEY_HERE",
+        "client_secret": "YOUR_API_KEY_HERE"
+    },
+
     "apn": {
         "connection": {
             "gateway": "gateway.sandbox.push.apple.com",

--- a/example.config.json
+++ b/example.config.json
@@ -8,8 +8,8 @@
     },
 
     "adm": {
-        "client_id": "YOUR_API_KEY_HERE",
-        "client_secret": "YOUR_API_KEY_HERE"
+        "client_id": "YOUR_CLIENT_ID_HERE",
+        "client_secret": "YOUR_CLIENT_SECRET_HERE"
     },
 
     "apn": {

--- a/lib/ADMPusher.js
+++ b/lib/ADMPusher.js
@@ -1,0 +1,78 @@
+/**
+ * Created with JetBrains PhpStorm.
+ * User: apateiro
+ * Date: 2016-06-05
+ * Time: 11:43
+ * To change this template use File | Settings | File Templates.
+ */
+
+var config = require('./Config');
+var _ = require('lodash');
+var adm = require('node-adm');
+var pushAssociations = require('./PushAssociations');
+
+
+var push = function (tokens, message) {
+    var mappedResults = [];
+    function send_push(token, is_last){
+        admSender().send(message, token, function (err, res) {
+            if(err) console.log(err);
+
+            if (res) {
+                mappedResults.push(_.merge({token: token}, res));
+            }
+
+            if(is_last){
+                handleResults(mappedResults);
+            }
+        })
+    }
+
+    //It seems node-adm doesn't allow multiple registrationId,
+    //so call the send method for each registration id received here
+    _(tokens).forEach(function(token, index) {
+        send_push(token, (index == tokens.length -1));
+    });
+
+};
+
+var handleResults = function (results) {
+    var idsToUpdate = [],
+        idsToDelete = [];
+
+    results.forEach(function (result) {
+        if (!!result.registration_id) {
+            idsToUpdate.push({from: result.token, to: result.registration_id});
+
+        } else if (result.error === 'InvalidRegistration' || result.error === 'NotRegistered') {
+            idsToDelete.push(result.token);
+        }
+    });
+
+    if (idsToUpdate.length > 0) pushAssociations.updateTokens(idsToUpdate);
+    if (idsToDelete.length > 0) pushAssociations.removeDevices(idsToDelete);
+};
+
+var buildPayload = function (options) {
+    //TODO Implement payload object formatter and validator
+    //Expected format;
+    /*
+    {
+        data: {
+            message: "Hello"
+        },
+        consolidationKey: "Some Key",
+        expiresAfter: 86400
+    }
+    */
+    return options;
+};
+
+var admSender = _.once(function() {
+    return new adm.Sender(config.get('adm'));
+});
+
+module.exports = {
+    push: push,
+    buildPayload:buildPayload
+};

--- a/lib/PushAssociations.js
+++ b/lib/PushAssociations.js
@@ -17,7 +17,7 @@ var initialize = _.once(function () {
         type: {
             type: 'String',
             required: true,
-            enum: ['ios', 'android'],
+            enum: ['ios', 'android', 'amazon'],
             lowercase: true
         },
         token: {

--- a/lib/PushController.js
+++ b/lib/PushController.js
@@ -8,12 +8,14 @@
 var _ = require('lodash'),
     pushAssociations = require('./PushAssociations'),
     apnPusher = require('./APNPusher'),
-    gcmPusher = require('./GCMPusher');
+    gcmPusher = require('./GCMPusher'),
+    admPusher = require('./ADMPusher');
 
 
-var send = function (pushAssociations, androidPayload, iosPayload) {
+var send = function (pushAssociations, androidPayload, iosPayload, amazonPayload) {
     var androidTokens = _(pushAssociations).where({type: 'android'}).map('token').value();
     var iosTokens = _(pushAssociations).where({type: 'ios'}).map('token').value();
+    var amazonTokens = _(pushAssociations).where({type: 'amazon'}).map('token').value();
 
     if (androidPayload && androidTokens.length > 0) {
         var gcmPayload = gcmPusher.buildPayload(androidPayload);
@@ -23,6 +25,11 @@ var send = function (pushAssociations, androidPayload, iosPayload) {
     if (iosPayload && iosTokens.length > 0) {
         var apnPayload = apnPusher.buildPayload(iosPayload);
         apnPusher.push(iosTokens, apnPayload);
+    }
+
+    if (amazonTokens && amazonTokens.length > 0) {
+        var admPayload = admPusher.buildPayload(amazonPayload);
+        admPusher.push(amazonTokens, admPayload);
     }
 };
 

--- a/lib/Web.js
+++ b/lib/Web.js
@@ -103,26 +103,31 @@ function sendNotifications(notifs) {
         var users = notif.users,
             androidPayload = notif.android,
             iosPayload = notif.ios,
+            amazonPayload = notif.amazon,
             target;
 
-        if (androidPayload && iosPayload) {
+        if (androidPayload && iosPayload && amazonPayload) {
             target = 'all'
-        } else if (iosPayload) {
-            target = 'ios'
-        } else if (androidPayload) {
-            target = 'android';
+        } else {
+            target = [];
+            if (androidPayload) target.push('android');
+            if (iosPayload) target.push('ios');
+            if (amazonPayload) target.push('amazon');
         }
 
         var fetchUsers = users ? pushAssociations.getForUsers : pushAssociations.getAll,
             callback = function (err, pushAssociations) {
                 if (err) return;
 
-                if (target !== 'all') {
+                if (target !== 'all' && target.length) {
                     // TODO: do it in mongo instead of here ...
-                    pushAssociations = _.where(pushAssociations, {'type': target});
+                    //pushAssociations = _.where(pushAssociations, {'type': target});
+                    pushAssociations = _.filter(pushAssociations, function(association){
+                        return _.contains(target, association.type)
+                    });
                 }
 
-                push.send(pushAssociations, androidPayload, iosPayload);
+                push.send(pushAssociations, androidPayload, iosPayload, amazonPayload);
             },
             args = users ? [users, callback] : [callback];
 

--- a/package.json
+++ b/package.json
@@ -1,16 +1,18 @@
 {
   "name": "node-pushserver",
-  "version": "0.5.4",
-  "description": "Cross-platform Push Notifications. A project providing a generic API to push messages using Apple's APN and Google's GCM services.",
+  "version": "0.6.0",
+  "description": "Cross-platform Push Notifications. A project providing a generic API to push messages using Apple's APN, Google's GCM and Amazon's ADM services.",
   "keywords": [
     "push",
     "gcm",
     "apn",
+    "adm",
     "mongodb"
   ],
   "dependencies": {
     "mongoose": "~3.6.11",
     "node-gcm": "~0.13.0",
+    "node-adm": "~0.9.1",
     "lodash": "~1.3.1",
     "apn": "~1.7.5",
     "express": "~3.2.6",


### PR DESCRIPTION
Add Pusher and users association with type "amazon" for notifications via Amazon Device Messaging.

Based on [node-adm](https://github.com/umano/node-adm)