### PR TITLE
Updated mongoose to v3.8 to support MongoDB v3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "mongodb"
   ],
   "dependencies": {
-    "mongoose": "~3.6.11",
+    "mongoose": "~3.8.0",
     "node-gcm": "~0.13.0",
     "lodash": "~1.3.1",
     "apn": "~1.7.5",


### PR DESCRIPTION
Added support for **MongoDB v3.x**

Mongoose v.3.8.x offers MongoDB 3 support. [See more](https://github.com/Automattic/mongoose#stability)